### PR TITLE
SimpleRouter: fix compatiblity with non-stringable (e.g. Closure) default parameter values

### DIFF
--- a/src/Routing/SimpleRouter.php
+++ b/src/Routing/SimpleRouter.php
@@ -47,7 +47,7 @@ class SimpleRouter implements Router
 	{
 		// remove default values; null values are retain
 		foreach ($this->defaults as $key => $value) {
-			if (isset($params[$key]) && (string) $params[$key] === (string) $value) {
+			if (isset($params[$key]) && $params[$key] == $value) { // default value may be object, intentionally ==
 				unset($params[$key]);
 			}
 		}

--- a/tests/SimpleRouter/objectParameter.phpt
+++ b/tests/SimpleRouter/objectParameter.phpt
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Test: Nette\Routing\SimpleRouter object parameter default value.
+ */
+
+declare(strict_types=1);
+
+use Nette\Http;
+use Nette\Routing\SimpleRouter;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$callback = function (): string {
+	return 'test';
+};
+
+$router = new SimpleRouter([
+	'presenter' => 'Nette:Micro',
+	'callback' => $callback,
+]);
+
+$httpRequest = new Http\Request(new Http\UrlScript('https://nette.org/?foo=bar'));
+
+$params = $router->match($httpRequest);
+Assert::same([
+	'foo' => 'bar',
+	'presenter' => 'Nette:Micro',
+	'callback' => $callback,
+], $params);
+
+$res = $router->constructUrl($params, $httpRequest->getUrl());
+Assert::same('https://nette.org/?foo=bar', $res);


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

The bug was intoroduced in d989c52fa70708816253f2adab7f57ba039a4b4f. `SimpleRouter` should support non-stringable (e.g. Closure instance) default parameter values - a typical use case is `Nette:Micro` presenter.