### PR TITLE
[IGNORE]

### DIFF
--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -159,6 +159,7 @@ class Route implements Router
 		// 1) URL MASK
 		$url = $httpRequest->getUrl();
 		$re = $this->re;
+        $basePath = $url->getBasePath() . '/';
 
 		if ($this->type === self::Host) {
 			$host = $url->getHost();
@@ -167,7 +168,7 @@ class Route implements Router
                 ? [$host]
                 : array_reverse(explode('.', $host));
 			$re = strtr($re, [
-				'/%basePath%/' => preg_quote($url->getBasePath(), '#'),
+                '/%basePath%/' => preg_quote($basePath, '#'),
 				'%tld%' => preg_quote($parts[0], '#'),
 				'%domain%' => preg_quote(isset($parts[1]) ? "$parts[1].$parts[0]" : $parts[0], '#'),
 				'%sld%' => preg_quote($parts[1] ?? '', '#'),
@@ -175,7 +176,6 @@ class Route implements Router
 			]);
 
 		} elseif ($this->type === self::Relative) {
-			$basePath = $url->getBasePath();
 			if (strncmp($url->getPath(), $basePath, strlen($basePath)) !== 0) {
 				return null;
 			}
@@ -260,9 +260,10 @@ class Route implements Router
 			return null;
 		}
 
-		// absolutize
+        // absolutize
+        $basePath = $refUrl->getBasePath() . '/';
 		if ($this->type === self::Relative) {
-			$url = (($tmp = $refUrl->getAuthority()) ? "//$tmp" : '') . $refUrl->getBasePath() . $url;
+            $url = (($tmp = $refUrl->getAuthority()) ? "//$tmp" : '') . $basePath . $url;
 
 		} elseif ($this->type === self::Path) {
 			$url = (($tmp = $refUrl->getAuthority()) ? "//$tmp" : '') . $url;
@@ -274,7 +275,7 @@ class Route implements Router
                 : array_reverse(explode('.', $host));
             $port = $refUrl->getDefaultPort() === ($tmp = $refUrl->getPort()) ? '' : ':' . $tmp;
 			$url = strtr($url, [
-				'/%basePath%/' => $refUrl->getBasePath(),
+                '/%basePath%/' => $basePath,
 				'%tld%' => $parts[0] . $port,
 				'%domain%' => (isset($parts[1]) ? "$parts[1].$parts[0]" : $parts[0]) . $port,
 				'%sld%' => $parts[1] ?? '',

--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -167,7 +167,7 @@ class Route implements Router
                 ? [$host]
                 : array_reverse(explode('.', $host));
 			$re = strtr($re, [
-				'/%basePath%/' => preg_quote($url->getBasePath(), '#'),
+                '/%basePath%/' => preg_quote($url->getBasePath() . '/', '#'),
 				'%tld%' => preg_quote($parts[0], '#'),
 				'%domain%' => preg_quote(isset($parts[1]) ? "$parts[1].$parts[0]" : $parts[0], '#'),
 				'%sld%' => preg_quote($parts[1] ?? '', '#'),
@@ -176,11 +176,11 @@ class Route implements Router
 
 		} elseif ($this->type === self::Relative) {
 			$basePath = $url->getBasePath();
-			if (strncmp($url->getPath(), $basePath, strlen($basePath)) !== 0) {
+            if (strncmp($url->getPath(), $basePath.'/', strlen($basePath.'/')) !== 0) {
 				return null;
 			}
 
-			$path = substr($url->getPath(), strlen($basePath));
+            $path = substr($url->getPath(), strlen($basePath.'/'));
 
 		} else {
 			$path = $url->getPath();
@@ -262,7 +262,7 @@ class Route implements Router
 
 		// absolutize
 		if ($this->type === self::Relative) {
-			$url = (($tmp = $refUrl->getAuthority()) ? "//$tmp" : '') . $refUrl->getBasePath() . $url;
+            $url = (($tmp = $refUrl->getAuthority()) ? "//$tmp" : '') . $refUrl->getBasePath() . '/' . $url;
 
 		} elseif ($this->type === self::Path) {
 			$url = (($tmp = $refUrl->getAuthority()) ? "//$tmp" : '') . $url;
@@ -274,7 +274,7 @@ class Route implements Router
                 : array_reverse(explode('.', $host));
             $port = $refUrl->getDefaultPort() === ($tmp = $refUrl->getPort()) ? '' : ':' . $tmp;
 			$url = strtr($url, [
-				'/%basePath%/' => $refUrl->getBasePath(),
+                '/%basePath%/' => $refUrl->getBasePath() . '/',
 				'%tld%' => $parts[0] . $port,
 				'%domain%' => (isset($parts[1]) ? "$parts[1].$parts[0]" : $parts[0]) . $port,
 				'%sld%' => $parts[1] ?? '',

--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -163,9 +163,9 @@ class Route implements Router
 		if ($this->type === self::Host) {
 			$host = $url->getHost();
 			$path = '//' . $host . $url->getPath();
-			$parts = ip2long($host)
-				? [$host]
-				: array_reverse(explode('.', $host));
+            $parts = filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)
+                ? [$host]
+                : array_reverse(explode('.', $host));
 			$re = strtr($re, [
 				'/%basePath%/' => preg_quote($url->getBasePath(), '#'),
 				'%tld%' => preg_quote($parts[0], '#'),
@@ -269,10 +269,10 @@ class Route implements Router
 
 		} else {
 			$host = $refUrl->getHost();
-			$parts = ip2long($host)
-				? [$host]
-				: array_reverse(explode('.', $host));
-			$port = $refUrl->getDefaultPort() === ($tmp = $refUrl->getPort()) ? '' : ':' . $tmp;
+            $parts = filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)
+                ? [$host]
+                : array_reverse(explode('.', $host));
+            $port = $refUrl->getDefaultPort() === ($tmp = $refUrl->getPort()) ? '' : ':' . $tmp;
 			$url = strtr($url, [
 				'/%basePath%/' => $refUrl->getBasePath(),
 				'%tld%' => $parts[0] . $port,

--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -159,7 +159,6 @@ class Route implements Router
 		// 1) URL MASK
 		$url = $httpRequest->getUrl();
 		$re = $this->re;
-        $basePath = $url->getBasePath() . '/';
 
 		if ($this->type === self::Host) {
 			$host = $url->getHost();
@@ -168,7 +167,7 @@ class Route implements Router
                 ? [$host]
                 : array_reverse(explode('.', $host));
 			$re = strtr($re, [
-                '/%basePath%/' => preg_quote($basePath, '#'),
+				'/%basePath%/' => preg_quote($url->getBasePath(), '#'),
 				'%tld%' => preg_quote($parts[0], '#'),
 				'%domain%' => preg_quote(isset($parts[1]) ? "$parts[1].$parts[0]" : $parts[0], '#'),
 				'%sld%' => preg_quote($parts[1] ?? '', '#'),
@@ -176,6 +175,7 @@ class Route implements Router
 			]);
 
 		} elseif ($this->type === self::Relative) {
+			$basePath = $url->getBasePath();
 			if (strncmp($url->getPath(), $basePath, strlen($basePath)) !== 0) {
 				return null;
 			}
@@ -260,10 +260,9 @@ class Route implements Router
 			return null;
 		}
 
-        // absolutize
-        $basePath = $refUrl->getBasePath() . '/';
+		// absolutize
 		if ($this->type === self::Relative) {
-            $url = (($tmp = $refUrl->getAuthority()) ? "//$tmp" : '') . $basePath . $url;
+			$url = (($tmp = $refUrl->getAuthority()) ? "//$tmp" : '') . $refUrl->getBasePath() . $url;
 
 		} elseif ($this->type === self::Path) {
 			$url = (($tmp = $refUrl->getAuthority()) ? "//$tmp" : '') . $url;
@@ -275,7 +274,7 @@ class Route implements Router
                 : array_reverse(explode('.', $host));
             $port = $refUrl->getDefaultPort() === ($tmp = $refUrl->getPort()) ? '' : ':' . $tmp;
 			$url = strtr($url, [
-                '/%basePath%/' => $basePath,
+				'/%basePath%/' => $refUrl->getBasePath(),
 				'%tld%' => $parts[0] . $port,
 				'%domain%' => (isset($parts[1]) ? "$parts[1].$parts[0]" : $parts[0]) . $port,
 				'%sld%' => $parts[1] ?? '',

--- a/src/Routing/RouteList.php
+++ b/src/Routing/RouteList.php
@@ -67,7 +67,7 @@ class RouteList implements Router
 			$url = $httpRequest->getUrl();
 			$relativePath = $url->getRelativePath();
 			if (strncmp($relativePath, $this->path, strlen($this->path)) === 0) {
-				$url = $url->withPath($url->getPath(), $url->getBasePath() . $this->path);
+                $url = $url->withPath($url->getPath(), $url->getBasePath() . '/' . $this->path);
 			} elseif ($relativePath . '/' === $this->path) {
 				$url = $url->withPath($url->getPath() . '/');
 			} else {
@@ -104,7 +104,7 @@ class RouteList implements Router
 
 		if ($this->path) {
 			if (!isset($this->refUrlCache[$refUrl])) {
-				$this->refUrlCache[$refUrl] = $refUrl->withPath($refUrl->getBasePath() . $this->path);
+                $this->refUrlCache[$refUrl] = $refUrl->withPath($refUrl->getBasePath() . '/' . $this->path);
 			}
 
 			$refUrl = $this->refUrlCache[$refUrl];


### PR DESCRIPTION

There is a bug in implementation of system variable $basePath in Nette + Latte. The variable is created in UrlScript::getBasePath() with ending /. It is used in 3 different nette packages in 5 different classes:

nette/application
	MicroPresenter
	TemplateFactory

nette/routing
	Route
	RouteList

nette/http
	UrlScript

In latte template file or micropresenter is injected $basePath without ending /. Unfortunately UrlScript::getBasePath() is a part of public API and different value is a very misleading. The purpose of this PR/RFC is unify $basePath in all nette packages to have everywere identical value.

I will submit 3 separate PR for every package + publish on forum nette more deep explanation of this RFC.

On one hand, this PR is a serious BC break, but on the other hand, the existing 'split personality' of the variable into a version with a trailing slash and a version without a trailing slash is FAR WORSE. Therefore, I recommend unify the value of $basePath regardless of the BC break.

